### PR TITLE
Configuring .gitignore to ignore keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Environment Credentials
+/settings.py


### PR DESCRIPTION
Third attempt at configuring Django environment. This one should be a pre-requisite to Django configuration so that settings.py files (including environment credentials) are appropriately ignored.